### PR TITLE
Add ITextModel and show how SyntaxHighlighting should work over multi…

### DIFF
--- a/Terminal.Gui/Views/ITextModel.cs
+++ b/Terminal.Gui/Views/ITextModel.cs
@@ -1,0 +1,9 @@
+﻿// TextView.cs: multi-line text editing
+using System.Collections.Generic;
+
+namespace Terminal.Gui {
+	public interface ITextModel {
+		int Count { get; }
+		List<RuneCell> GetLine (int line);
+	}
+}

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -13,7 +13,7 @@ namespace Terminal.Gui {
 	/// <summary>
 	/// Represents a single row/column within the <see cref="TextView"/>. Includes the glyph and the foreground/background colors.
 	/// </summary>
-	public struct RuneCell {
+	public class RuneCell {
 		/// <summary>
 		/// The glyph to draw.
 		/// </summary>
@@ -25,7 +25,7 @@ namespace Terminal.Gui {
 		public Attribute? Attribute { get; set; }
 	}
 
-	class TextModel {
+	class TextModel : ITextModel{
 		List<List<RuneCell>> _lines = new List<List<RuneCell>> ();
 
 		public event EventHandler LinesLoaded;
@@ -159,6 +159,7 @@ namespace Terminal.Gui {
 		}
 
 		public string FilePath { get; set; }
+
 
 		/// <summary>
 		/// The number of text lines in the model
@@ -1387,6 +1388,13 @@ namespace Terminal.Gui {
 	///  </list>
 	/// </remarks>
 	public class TextView : View {
+
+		/// <summary>
+		/// The internal representation of <see cref="Text"/> as <see cref="RuneCell"/>.
+		/// Can be used for advanced highlighting/parsing etc.
+		/// </summary>
+		public ITextModel TextViewModel => _model;
+
 		TextModel _model = new TextModel ();
 		int _topRow;
 		int _leftColumn;

--- a/UICatalog/Scenarios/SyntaxHighlighting.cs
+++ b/UICatalog/Scenarios/SyntaxHighlighting.cs
@@ -37,7 +37,7 @@ namespace UICatalog.Scenarios {
 			});
 			Application.Top.Add (menu);
 
-			textView = new SqlTextView () {
+			textView = new TextView () {
 				X = 0,
 				Y = 0,
 				Width = Dim.Fill (),
@@ -54,7 +54,7 @@ namespace UICatalog.Scenarios {
 
 			ApplyHighlighting ();
 
-			textView.TextChanged += (s,e)=> ApplyHighlighting ();
+			textView.KeyPress += (s,e)=> ApplyHighlighting ();
 
 			Application.Top.Add (statusBar);
 		}
@@ -71,7 +71,7 @@ namespace UICatalog.Scenarios {
 
 				for(int x=0;x<line.Count;x++) {
 					if (line [x].Rune == quoteRune) {
-						areInQuotes = true;
+						areInQuotes = !areInQuotes;
 					}
 					if(areInQuotes) {
 						line [x].Attribute = magenta;
@@ -93,7 +93,7 @@ namespace UICatalog.Scenarios {
 		{
 			Application.RequestStop ();
 		}
-
+		/*
 		private class SqlTextView : TextView {
 
 			private HashSet<string> keywords = new HashSet<string> (StringComparer.CurrentCultureIgnoreCase);
@@ -224,6 +224,6 @@ namespace UICatalog.Scenarios {
 
 				return current?.Trim ();
 			}
-		}
+		}*/
 	}
 }


### PR DESCRIPTION
Hey @BDisp this is great start.  But one of the reasons to change to `RuneCell` is to allow user to modify colour 'per cell' directly.

Here is a PR that shows how I think syntax highlighting should work.

Let me know what you think

The most important bit is that if the user changes the `Attribute` on a rune in the `TextModel` then that should be respected by `TextView`.

So wherever `TextView` is about to output a `RuneCell` to the UI it needs to check to see if it has an explicit color set on it and if it does to use that instead of its GetColorNormal.

See in this code I have written that the magenta isn't being highlighted currently:

![image](https://github.com/BDisp/Terminal.Gui/assets/31306100/fa10b30a-e37c-47ea-9907-0f638fb9e466)
