### PR TITLE
Forces non-normalized CMs to be ignored.

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/NetDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/NetDriver.cs
@@ -784,8 +784,9 @@ internal class NetDriver : ConsoleDriver {
 						} else if (lastCol == -1) {
 							lastCol = col;
 						}
-						if (lastCol + 1 < cols)
+						if (lastCol + 1 < cols) {
 							lastCol++;
+						}
 						continue;
 					}
 
@@ -809,14 +810,19 @@ internal class NetDriver : ConsoleDriver {
 					}
 					outputWidth++;
 					var rune = (Rune)Contents [row, col].Rune;
-					output.Append (rune.ToString ());
+					output.Append (rune);
 					if (Contents [row, col].CombiningMarks.Count > 0) {
-						foreach (var combMark in Contents [row, col].CombiningMarks) {
-							output.Append (combMark.ToString ());
-						}
-						WriteToConsole (output, ref lastCol, row, ref outputWidth);
-						SetCursorPosition (col - 1, row);
-					} else if (rune.IsSurrogatePair () && rune.GetColumns () < 2) {
+						// AtlasEngine does not support NON-NORMALIZED combining marks in a way
+						// compatible with the driver architecture. Any CMs (except in the first col)
+						// are correctly combined with the base char, but are ALSO treated as 1 column
+						// width codepoints E.g. `echo "[e`u{0301}`u{0301}]"` will output `[é  ]`.
+						// 
+						// For now, we just ignore the list of CMs.
+						//foreach (var combMark in Contents [row, col].CombiningMarks) {
+						//	output.Append (combMark);
+						//}
+						// WriteToConsole (output, ref lastCol, row, ref outputWidth);
+					} else  if ((rune.IsSurrogatePair () && rune.GetColumns () < 2)) {
 						WriteToConsole (output, ref lastCol, row, ref outputWidth);
 						SetCursorPosition (col - 1, row);
 					}

--- a/Terminal.Gui/Drawing/Cell.cs
+++ b/Terminal.Gui/Drawing/Cell.cs
@@ -9,21 +9,26 @@ namespace Terminal.Gui;
 /// (e.g. <see cref="LineCanvas"/> and <see cref="ConsoleDriver"/>).
 /// </summary>
 public class Cell {
+	Rune _rune;
 	/// <summary>
 	/// The character to display. If <see cref="Rune"/> is <see langword="null"/>, then <see cref="Rune"/> is ignored.
 	/// </summary>
-	public Rune Rune { get; set; }
+	public Rune Rune {
+		get => _rune;
+		set {
+			CombiningMarks.Clear ();
+			_rune = value;
+		}
+	}
 
-	// TODO: Uncomment this once combining sequences that could not be normalized are supported.
-	///// <summary>
-	///// The combining mark for <see cref="Rune"/> that when combined makes this Cell a combining sequence that could
-	///// not be normalized to a single Rune.
-	///// If <see cref="CombiningMark"/> is <see langword="null"/>, then <see cref="CombiningMark"/> is ignored.
-	///// </summary>
-	///// <remarks>
-	///// Only valid in the rare case where <see cref="Rune"/> is a combining sequence that could not be normalized to a single Rune.
-	///// </remarks>
-	internal List<Rune> CombiningMarks { get; set; } = new ();
+	/// <summary>
+	/// The combining marks for <see cref="Rune"/> that when combined makes this Cell a combining sequence.
+	/// If <see cref="CombiningMarks"/> empty, then <see cref="CombiningMarks"/> is ignored.
+	/// </summary>
+	/// <remarks>
+	/// Only valid in the rare case where <see cref="Rune"/> is a combining sequence that could not be normalized to a single Rune.
+	/// </remarks>
+	internal List<Rune> CombiningMarks { get; } = new List<Rune> ();
 
 	/// <summary>
 	/// The attributes to use when drawing the Glyph.

--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -1411,7 +1411,8 @@ namespace Terminal.Gui {
 					} else {
 						Application.Driver?.AddRune (rune);
 					}
-					var runeWidth = Math.Max (rune.GetColumns (), 1);
+					// BUGBUG: I think this is a bug. If rune is a combining mark current should not be incremented.
+					var runeWidth = rune.GetColumns (); //Math.Max (rune.GetColumns (), 1);
 					if (isVertical) {
 						current++;
 					} else {

--- a/UICatalog/Scenarios/CombiningMarks.cs
+++ b/UICatalog/Scenarios/CombiningMarks.cs
@@ -1,0 +1,35 @@
+using Terminal.Gui;
+
+namespace UICatalog.Scenarios {
+	[ScenarioMetadata (Name: "Combining Marks", Description: "Illustrates how Unicode Combining Marks work (or don't).")]
+	[ScenarioCategory ("Text and Formatting")]
+	public class CombiningMarks : Scenario {
+		public override void Init ()
+		{
+			Application.Init ();
+			ConfigurationManager.Themes.Theme = Theme;
+			ConfigurationManager.Apply ();
+			Application.Top.ColorScheme = Colors.ColorSchemes [TopLevelColorScheme];
+		}
+
+		public override void Setup ()
+		{
+			Application.Top.DrawContentComplete += (s, e) => {
+				Application.Driver.Move (0, 0);
+				Application.Driver.AddStr ("Terminal.Gui only supports combining marks that normalize. See Issue #2616.");
+				Application.Driver.Move (0, 2);
+				Application.Driver.AddStr ("\u0301\u0301\u0328<- \"\\u301\\u301\\u328]\" using AddStr.");
+				Application.Driver.Move (0, 3);
+				Application.Driver.AddStr ("[a\u0301\u0301\u0328]<- \"[a\\u301\\u301\\u328]\" using AddStr.");
+				Application.Driver.Move (0, 4);
+				Application.Driver.AddRune ('[');
+				Application.Driver.AddRune ('a');
+				Application.Driver.AddRune ('\u0301');
+				Application.Driver.AddRune ('\u0301');
+				Application.Driver.AddRune ('\u0328');
+				Application.Driver.AddRune (']');
+				Application.Driver.AddStr ("<- \"[a\\u301\\u301\\u328]\" using AddRune for each.");
+			};
+		}
+	}
+}

--- a/UICatalog/Scenarios/TabViewExample.cs
+++ b/UICatalog/Scenarios/TabViewExample.cs
@@ -67,9 +67,8 @@ namespace UICatalog.Scenarios {
 				"Long name Tab, I mean seriously long.  Like you would not believe how long this tab's name is its just too much really woooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooowwww thats long",
 				 new Label ("This tab has a very long name which should be truncated.  See TabView.MaxTabTextWidth")),
 				 false);
-			tabView.AddTab (new Tab ("Les Mise" + Char.ConvertFromUtf32 (Int32.Parse ("0301", NumberStyles.HexNumber)) + "rables", new Label ("This tab name is unicode")), false);
-			tabView.AddTab (new Tab ("Les Mise" + Char.ConvertFromUtf32 (Int32.Parse ("0328", NumberStyles.HexNumber)) + Char.ConvertFromUtf32 (Int32.Parse ("0301", NumberStyles.HexNumber)) + "rables", new Label ("This tab name has two unicode combining masks")), false);
-
+			tabView.AddTab (new Tab ("Les Mise" + '\u0301' + "rables", new Label ("This tab name is unicode")), false);
+			tabView.AddTab (new Tab ("Les Mise" + '\u0328' + '\u0301' + "rables", new Label ("This tab name has two combining marks. Only one will show due to Issue #2616.")), false);
 			for (int i = 0; i < 100; i++) {
 				tabView.AddTab (new Tab ($"Tab{i}", new Label ($"Welcome to tab {i}")), false);
 			}

--- a/UICatalog/Scenarios/Unicode.cs
+++ b/UICatalog/Scenarios/Unicode.cs
@@ -42,9 +42,12 @@ namespace UICatalog.Scenarios {
 
 			label = new Label ("Label (CanFocus):") { X = Pos.X (label), Y = Pos.Bottom (label) + 1 };
 			Win.Add (label);
-			testlabel = new Label ("Стоял &он, дум великих полн") { X = 20, Y = Pos.Y (label), Width = Dim.Percent (50), CanFocus = true, HotKeySpecifier = new Rune ('&') };
+			var sb = new StringBuilder ();
+			sb.Append ('e');
+			sb.Append ('\u0301');
+			sb.Append ('\u0301');
+			testlabel = new Label ($"Should be [e with two accents, but isn't due to #2616]: [{sb}]") { X = 20, Y = Pos.Y (label), Width = Dim.Percent (50), CanFocus = true, HotKeySpecifier = new Rune ('&') };
 			Win.Add (testlabel);
-
 			label = new Label ("Button:") { X = Pos.X (label), Y = Pos.Bottom (label) + 1 };
 			Win.Add (label);
 			var button = new Button ("A123456789♥♦♣♠JQK") { X = 20, Y = Pos.Y (label) };

--- a/UnitTests/ConsoleDrivers/ContentsTests.cs
+++ b/UnitTests/ConsoleDrivers/ContentsTests.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -16,6 +17,23 @@ public class ContentsTests {
 	{
 		ConsoleDriver.RunningUnitTests = true;
 		this.output = output;
+	}
+
+
+	[Theory]
+	[InlineData (typeof (FakeDriver))]
+	[InlineData (typeof (NetDriver))]
+	//[InlineData (typeof (CursesDriver))] // TODO: Uncomment when #2796 and #2615 are fixed
+	//[InlineData (typeof (WindowsDriver))] // TODO: Uncomment when #2610 is fixed
+	public void AddStr_Combining_Character_1st_Column (Type driverType)
+	{
+		var driver = (ConsoleDriver)Activator.CreateInstance (driverType);
+		driver.Init ();
+		var expected = "\u0301!";
+		driver.AddStr ("\u0301!"); // acute accent + exclamation mark
+		TestHelpers.AssertDriverContentsAre (expected, output, driver);
+
+		driver.End ();
 	}
 
 	[Theory]
@@ -33,45 +51,41 @@ public class ContentsTests {
 		var expected = "é";
 
 		driver.AddStr (combined);
-		TestHelpers.AssertDriverContentsWithFrameAre (expected, output, driver);
+		TestHelpers.AssertDriverContentsAre (expected, output, driver);
 
 		// 3 char combine
 		// a + ogonek + acute = <U+0061, U+0328, U+0301> ( ą́ )
 		var ogonek = new System.Text.Rune (0x0328); // Combining ogonek (a small hook or comma shape)
 		combined = "a" + ogonek + acuteaccent;
-		expected = "ą́";
+		expected = ("a" + ogonek).Normalize(NormalizationForm.FormC); // See Issue #2616
 
 		driver.Move (0, 0);
 		driver.AddStr (combined);
-		TestHelpers.AssertDriverContentsWithFrameAre (expected, output, driver);
+		TestHelpers.AssertDriverContentsAre (expected, output, driver);
 
 		// e + ogonek + acute = <U+0061, U+0328, U+0301> ( ę́́ )
 		combined = "e" + ogonek + acuteaccent;
-		expected = "ę́́";
+		expected = ("e" + ogonek).Normalize (NormalizationForm.FormC); // See Issue #2616
 
 		driver.Move (0, 0);
 		driver.AddStr (combined);
-		TestHelpers.AssertDriverContentsWithFrameAre (expected, output, driver);
+		TestHelpers.AssertDriverContentsAre (expected, output, driver);
 
 		// i + ogonek + acute = <U+0061, U+0328, U+0301> ( į́́́ )
 		combined = "i" + ogonek + acuteaccent;
-		expected = "į́́́";
+		expected = ("i" + ogonek).Normalize (NormalizationForm.FormC); // See Issue #2616
 
 		driver.Move (0, 0);
 		driver.AddStr (combined);
-		TestHelpers.AssertDriverContentsWithFrameAre (expected, output, driver);
-
-		// o + ogonek + acute = <U+0061, U+0328, U+0301> ( ǫ́ )
-		combined = "o" + ogonek + acuteaccent;
-		expected = "ǫ́";
+		TestHelpers.AssertDriverContentsAre (expected, output, driver);
 
 		// u + ogonek + acute = <U+0061, U+0328, U+0301> ( ų́́́́ )
 		combined = "u" + ogonek + acuteaccent;
-		expected = "ų́́́́";
+		expected = ("u" + ogonek).Normalize (NormalizationForm.FormC); // See Issue #2616
 
 		driver.Move (0, 0);
 		driver.AddStr (combined);
-		TestHelpers.AssertDriverContentsWithFrameAre (expected, output, driver);
+		TestHelpers.AssertDriverContentsAre (expected, output, driver);
 
 		driver.End ();
 	}

--- a/UnitTests/TestHelpers.cs
+++ b/UnitTests/TestHelpers.cs
@@ -165,7 +165,6 @@ partial class TestHelpers {
 
 		for (int r = 0; r < driver.Rows; r++) {
 			for (int c = 0; c < driver.Cols; c++) {
-				// TODO: Remove hard-coded [0] once combining pairs is supported
 				Rune rune = contents [r, c].Rune;
 				if (rune.DecodeSurrogatePair (out char [] spair)) {
 					sb.Append (spair);
@@ -175,9 +174,10 @@ partial class TestHelpers {
 				if (rune.GetColumns () > 1) {
 					c++;
 				}
-				foreach (var combMark in contents [r, c].CombiningMarks) {
-					sb.Append ((char)combMark.Value);
-				}
+				// See Issue #2616
+				//foreach (var combMark in contents [r, c].CombiningMarks) {
+				//	sb.Append ((char)combMark.Value);
+				//}
 			}
 			sb.AppendLine ();
 		}
@@ -248,9 +248,10 @@ partial class TestHelpers {
 					h = r - y + 1;
 				}
 				if (x > -1) runes.Add (rune);
-				foreach (var combMark in contents [r, c].CombiningMarks) {
-					runes.Add (combMark);
-				}
+				// See Issue #2616
+				//foreach (var combMark in contents [r, c].CombiningMarks) {
+				//	runes.Add (combMark);
+				//}
 			}
 			if (runes.Count > 0) lines.Add (runes);
 		}


### PR DESCRIPTION
I think this is the best we can do until either:

a) AtlasEngine (Window Terminal) fixes how they handle cms that don't normalize 

OR

b) We rearchitect ConsoleDriver significantly (I have ideas how to do this, but it will be a major undertaking).