### PR TITLE
Makes Scroll clicks move proportionally

### DIFF
--- a/Terminal.Gui/Views/Scroll/Scroll.cs
+++ b/Terminal.Gui/Views/Scroll/Scroll.cs
@@ -165,10 +165,6 @@ public class Scroll : View
         return base.OnMouseEvent (mouseEvent);
     }
 
-    // TODO: Move this into "ScrollSlider" and override it there. Scroll can then subscribe to _slider.LayoutComplete and call AdjustSlider.
-    // QUESTION: I've been meaning to add a "View.FrameChanged" event (fired from LayoutComplete only if Frame has changed). Should we do that as part of this PR?
-    // QUESTION: Note I *did* add "View.ViewportChanged" in a previous PR.
-
     /// <summary>Virtual method called when <see cref="Position"/> has changed. Raises <see cref="PositionChanged"/>.</summary>
     protected virtual void OnPositionChanged (int position) { PositionChanged?.Invoke (this, new (in position)); }
 

--- a/Terminal.Gui/Views/Scroll/Scroll.cs
+++ b/Terminal.Gui/Views/Scroll/Scroll.cs
@@ -128,17 +128,21 @@ public class Scroll : View
         int location = Orientation == Orientation.Vertical ? mouseEvent.Position.Y : mouseEvent.Position.X;
         int barSize = BarSize;
 
-        (int topLeft, int bottomRight) sliderPos = _orientation == Orientation.Vertical
-                                                       ? new (_slider.Frame.Y, _slider.Frame.Bottom - 1)
-                                                       : new (_slider.Frame.X, _slider.Frame.Right - 1);
+        (int start, int end) sliderPos = _orientation == Orientation.Vertical
+                                             ? new (_slider.Frame.Y, _slider.Frame.Bottom - 1)
+                                             : new (_slider.Frame.X, _slider.Frame.Right - 1);
 
-        if (mouseEvent.Flags.HasFlag (MouseFlags.Button1Pressed) && location < sliderPos.topLeft)
+        if (mouseEvent.Flags.HasFlag (MouseFlags.Button1Pressed) && location < sliderPos.start)
         {
-            Position = Math.Max (Position - barSize, 0);
+            int distance = sliderPos.start - location;
+            int scrollAmount = (int)((double)distance / barSize * (Size - barSize));
+            Position = Math.Max (Position - scrollAmount, 0);
         }
-        else if (mouseEvent.Flags.HasFlag (MouseFlags.Button1Pressed) && location > sliderPos.bottomRight)
+        else if (mouseEvent.Flags.HasFlag (MouseFlags.Button1Pressed) && location > sliderPos.end)
         {
-            Position = Math.Min (Position + barSize, Size - barSize);
+            int distance = location - sliderPos.end;
+            int scrollAmount = (int)((double)distance / barSize * (Size - barSize));
+            Position = Math.Min (Position + scrollAmount, Size - barSize);
         }
         else if ((mouseEvent.Flags == MouseFlags.WheeledDown && Orientation == Orientation.Vertical)
                  || (mouseEvent.Flags == MouseFlags.WheeledRight && Orientation == Orientation.Horizontal))


### PR DESCRIPTION
See if you like this.

It makes it so that if you click in the scroll, outside of the slider, instead of just moving 1 position, scrollAmount is proportional to how far away from the slider you click. 