### PR TITLE
Integrate AnsiResponseParser<T> attempt 2

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/AnsiEscapeSequenceRequestStatus.cs
+++ b/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/AnsiEscapeSequenceRequestStatus.cs
@@ -8,6 +8,11 @@ namespace Terminal.Gui;
 /// <remarks></remarks>
 public class AnsiEscapeSequenceRequestStatus
 {
+    /// <summary>
+    /// The time at which the request was sent
+    /// </summary>
+    public DateTime Sent { get; } = DateTime.Now;
+
     /// <summary>Creates a new state of escape sequence request.</summary>
     /// <param name="ansiRequest">The <see cref="AnsiEscapeSequenceRequest"/> object.</param>
     public AnsiEscapeSequenceRequestStatus (AnsiEscapeSequenceRequest ansiRequest) { AnsiRequest = ansiRequest; }

--- a/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/AnsiResponseExpectation.cs
+++ b/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/AnsiResponseExpectation.cs
@@ -1,0 +1,7 @@
+﻿#nullable enable
+namespace Terminal.Gui;
+
+internal record AnsiResponseExpectation (string Terminator, Action<IHeld> Response, Action? Abandoned)
+{
+    public bool Matches (string cur) { return cur.EndsWith (Terminator); }
+}

--- a/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/AnsiResponseParser.cs
+++ b/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/AnsiResponseParser.cs
@@ -1,0 +1,444 @@
+﻿#nullable enable
+
+using System.Xml.Linq;
+
+namespace Terminal.Gui;
+
+internal abstract class AnsiResponseParserBase : IAnsiResponseParser
+{
+    protected object lockExpectedResponses = new ();
+
+    protected object lockState = new ();
+
+    /// <summary>
+    ///     Responses we are expecting to come in.
+    /// </summary>
+    protected readonly List<AnsiResponseExpectation> expectedResponses = new ();
+
+    /// <summary>
+    ///     Collection of responses that we <see cref="StopExpecting"/>.
+    /// </summary>
+    protected readonly List<AnsiResponseExpectation> lateResponses = new ();
+
+    /// <summary>
+    ///     Responses that you want to look out for that will come in continuously e.g. mouse events.
+    ///     Key is the terminator.
+    /// </summary>
+    protected readonly List<AnsiResponseExpectation> persistentExpectations = new ();
+
+    private AnsiResponseParserState _state = AnsiResponseParserState.Normal;
+
+    /// <inheritdoc />
+    public AnsiResponseParserState State
+    {
+        get => _state;
+        protected set
+        {
+            StateChangedAt = DateTime.Now;
+            _state = value;
+        }
+    }
+
+    protected readonly IHeld heldContent;
+
+    /// <summary>
+    ///     When <see cref="State"/> was last changed.
+    /// </summary>
+    public DateTime StateChangedAt { get; private set; } = DateTime.Now;
+
+    // These all are valid terminators on ansi responses,
+    // see CSI in https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Functions-using-CSI-_-ordered-by-the-final-character_s
+    // No - N or O
+    protected readonly HashSet<char> _knownTerminators = new (
+                                                              new []
+                                                              {
+                                                                  '@', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+
+                                                                  // No - N or O
+                                                                  'P', 'Q', 'R', 'S', 'T', 'W', 'X', 'Z',
+                                                                  '^', '`', '~',
+                                                                  'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
+                                                                  'l', 'm', 'n',
+                                                                  'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+                                                              });
+
+    protected AnsiResponseParserBase (IHeld heldContent) { this.heldContent = heldContent; }
+
+    protected void ResetState ()
+    {
+        State = AnsiResponseParserState.Normal;
+        heldContent.ClearHeld ();
+    }
+
+    /// <summary>
+    ///     Processes an input collection of objects <paramref name="inputLength"/> long.
+    ///     You must provide the indexers to return the objects and the action to append
+    ///     to output stream.
+    /// </summary>
+    /// <param name="getCharAtIndex">The character representation of element i of your input collection</param>
+    /// <param name="getObjectAtIndex">The actual element in the collection (e.g. char or Tuple&lt;char,T&gt;)</param>
+    /// <param name="appendOutput">
+    ///     Action to invoke when parser confirms an element of the current collection or a previous
+    ///     call's collection should be appended to the current output (i.e. append to your output List/StringBuilder).
+    /// </param>
+    /// <param name="inputLength">The total number of elements in your collection</param>
+    protected void ProcessInputBase (
+        Func<int, char> getCharAtIndex,
+        Func<int, object> getObjectAtIndex,
+        Action<object> appendOutput,
+        int inputLength
+    )
+    {
+        lock (lockState)
+        {
+            ProcessInputBaseImpl (getCharAtIndex, getObjectAtIndex, appendOutput, inputLength);
+        }
+    }
+
+    private void ProcessInputBaseImpl (
+        Func<int, char> getCharAtIndex,
+        Func<int, object> getObjectAtIndex,
+        Action<object> appendOutput,
+        int inputLength
+    )
+    {
+        var index = 0; // Tracks position in the input string
+
+        while (index < inputLength)
+        {
+            char currentChar = getCharAtIndex (index);
+            object currentObj = getObjectAtIndex (index);
+
+            bool isEscape = currentChar == '\x1B';
+
+            switch (State)
+            {
+                case AnsiResponseParserState.Normal:
+                    if (isEscape)
+                    {
+                        // Escape character detected, move to ExpectingBracket state
+                        State = AnsiResponseParserState.ExpectingBracket;
+                        heldContent.AddToHeld (currentObj); // Hold the escape character
+                    }
+                    else
+                    {
+                        // Normal character, append to output
+                        appendOutput (currentObj);
+                    }
+
+                    break;
+
+                case AnsiResponseParserState.ExpectingBracket:
+                    if (isEscape)
+                    {
+                        // Second escape so we must release first
+                        ReleaseHeld (appendOutput, AnsiResponseParserState.ExpectingBracket);
+                        heldContent.AddToHeld (currentObj); // Hold the new escape
+                    }
+                    else if (currentChar == '[')
+                    {
+                        // Detected '[', transition to InResponse state
+                        State = AnsiResponseParserState.InResponse;
+                        heldContent.AddToHeld (currentObj); // Hold the '['
+                    }
+                    else
+                    {
+                        // Invalid sequence, release held characters and reset to Normal
+                        ReleaseHeld (appendOutput);
+                        appendOutput (currentObj); // Add current character
+                    }
+
+                    break;
+
+                case AnsiResponseParserState.InResponse:
+                    heldContent.AddToHeld (currentObj);
+
+                    // Check if the held content should be released
+                    if (ShouldReleaseHeldContent ())
+                    {
+                        ReleaseHeld (appendOutput);
+                    }
+
+                    break;
+            }
+
+            index++;
+        }
+    }
+
+    private void ReleaseHeld (Action<object> appendOutput, AnsiResponseParserState newState = AnsiResponseParserState.Normal)
+    {
+        foreach (object o in heldContent.HeldToObjects ())
+        {
+            appendOutput (o);
+        }
+
+        State = newState;
+        heldContent.ClearHeld ();
+    }
+
+    // Common response handler logic
+    protected bool ShouldReleaseHeldContent ()
+    {
+        string cur = heldContent.HeldToString ();
+
+        lock (lockExpectedResponses)
+        {
+            // Look for an expected response for what is accumulated so far (since Esc)
+            if (MatchResponse (
+                               cur,
+                               expectedResponses,
+                               true,
+                               true))
+            {
+                return false;
+            }
+
+            // Also try looking for late requests - in which case we do not invoke but still swallow content to avoid corrupting downstream
+            if (MatchResponse (
+                               cur,
+                               lateResponses,
+                               false,
+                               true))
+            {
+                return false;
+            }
+
+            // Look for persistent requests
+            if (MatchResponse (
+                               cur,
+                               persistentExpectations,
+                               true,
+                               false))
+            {
+                return false;
+            }
+        }
+
+        // Finally if it is a valid ansi response but not one we are expect (e.g. its mouse activity)
+        // then we can release it back to input processing stream
+        if (_knownTerminators.Contains (cur.Last ()) && cur.StartsWith (AnsiEscapeSequenceRequestUtils.CSI))
+        {
+            // We have found a terminator so bail
+            State = AnsiResponseParserState.Normal;
+
+            // Maybe swallow anyway if user has custom delegate
+            bool swallow = ShouldSwallowUnexpectedResponse ();
+
+            if (swallow)
+            {
+                heldContent.ClearHeld ();
+
+                // Do not send back to input stream
+                return false;
+            }
+
+            // Do release back to input stream
+            return true;
+        }
+
+        return false; // Continue accumulating
+    }
+
+    /// <summary>
+    ///     <para>
+    ///         When overriden in a derived class, indicates whether the unexpected response
+    ///         currently in <see cref="heldContent"/> should be released or swallowed.
+    ///         Use this to enable default event for escape codes.
+    ///     </para>
+    ///     <remarks>
+    ///         Note this is only called for complete responses.
+    ///         Based on <see cref="_knownTerminators"/>
+    ///     </remarks>
+    /// </summary>
+    /// <returns></returns>
+    protected abstract bool ShouldSwallowUnexpectedResponse ();
+
+    private bool MatchResponse (string cur, List<AnsiResponseExpectation> collection, bool invokeCallback, bool removeExpectation)
+    {
+        // Check for expected responses
+        AnsiResponseExpectation? matchingResponse = collection.FirstOrDefault (r => r.Matches (cur));
+
+        if (matchingResponse?.Response != null)
+        {
+            if (invokeCallback)
+            {
+                matchingResponse.Response.Invoke (heldContent);
+            }
+
+            ResetState ();
+
+            if (removeExpectation)
+            {
+                collection.Remove (matchingResponse);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public void ExpectResponse (string terminator, Action<string> response, Action? abandoned, bool persistent)
+    {
+        lock (lockExpectedResponses)
+        {
+            if (persistent)
+            {
+                persistentExpectations.Add (new (terminator, h => response.Invoke (h.HeldToString ()), abandoned));
+            }
+            else
+            {
+                expectedResponses.Add (new (terminator, h => response.Invoke (h.HeldToString ()), abandoned));
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool IsExpecting (string terminator)
+    {
+        lock (lockExpectedResponses)
+        {
+            // If any of the new terminator matches any existing terminators characters it's a collision so true.
+            return expectedResponses.Any (r => r.Terminator.Intersect (terminator).Any ());
+        }
+    }
+
+    /// <inheritdoc/>
+    public void StopExpecting (string terminator, bool persistent)
+    {
+        lock (lockExpectedResponses)
+        {
+            if (persistent)
+            {
+                AnsiResponseExpectation [] removed = persistentExpectations.Where (r => r.Matches (terminator)).ToArray ();
+
+                foreach (var toRemove in removed)
+                {
+                    persistentExpectations.Remove (toRemove);
+                    toRemove.Abandoned?.Invoke ();
+                }
+            }
+            else
+            {
+                AnsiResponseExpectation [] removed = expectedResponses.Where (r => r.Terminator == terminator).ToArray ();
+
+                foreach (AnsiResponseExpectation r in removed)
+                {
+                    expectedResponses.Remove (r);
+                    lateResponses.Add (r);
+                    r.Abandoned?.Invoke ();
+                }
+            }
+        }
+    }
+}
+
+internal class AnsiResponseParser<T> : AnsiResponseParserBase
+{
+    public AnsiResponseParser () : base (new GenericHeld<T> ()) { }
+
+    /// <inheritdoc cref="AnsiResponseParser.UnknownResponseHandler"/>
+    public Func<IEnumerable<Tuple<char, T>>, bool> UnexpectedResponseHandler { get; set; } = _ => false;
+
+    public IEnumerable<Tuple<char, T>> ProcessInput (params Tuple<char, T> [] input)
+    {
+        List<Tuple<char, T>> output = new ();
+
+        ProcessInputBase (
+                          i => input [i].Item1,
+                          i => input [i],
+                          c => output.Add ((Tuple<char, T>)c),
+                          input.Length);
+
+        return output;
+    }
+
+    public IEnumerable<Tuple<char, T>> Release ()
+    {
+        // Lock in case Release is called from different Thread from parse
+        lock (lockState)
+        {
+            foreach (Tuple<char, T> h in HeldToEnumerable ())
+            {
+                yield return h;
+            }
+
+            ResetState ();
+        }
+    }
+
+    private IEnumerable<Tuple<char, T>> HeldToEnumerable () { return (IEnumerable<Tuple<char, T>>)heldContent.HeldToObjects (); }
+
+    /// <summary>
+    ///     'Overload' for specifying an expectation that requires the metadata as well as characters. Has
+    ///     a unique name because otherwise most lamdas will give ambiguous overload errors.
+    /// </summary>
+    /// <param name="terminator"></param>
+    /// <param name="response"></param>
+    /// <param name="abandoned"></param>
+    /// <param name="persistent"></param>
+    public void ExpectResponseT (string terminator, Action<IEnumerable<Tuple<char, T>>> response, Action? abandoned, bool persistent)
+    {
+        lock (lockExpectedResponses)
+        {
+            if (persistent)
+            {
+                persistentExpectations.Add (new (terminator, h => response.Invoke (HeldToEnumerable ()), abandoned));
+            }
+            else
+            {
+                expectedResponses.Add (new (terminator, h => response.Invoke (HeldToEnumerable ()), abandoned));
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override bool ShouldSwallowUnexpectedResponse () { return UnexpectedResponseHandler.Invoke (HeldToEnumerable ()); }
+}
+
+internal class AnsiResponseParser : AnsiResponseParserBase
+{
+    /// <summary>
+    ///     <para>
+    ///         Delegate for handling unrecognized escape codes. Default behaviour
+    ///         is to return <see langword="false"/> which simply releases the
+    ///         characters back to input stream for downstream processing.
+    ///     </para>
+    ///     <para>
+    ///         Implement a method to handle if you want and return <see langword="true"/> if you want the
+    ///         keystrokes 'swallowed' (i.e. not returned to input stream).
+    ///     </para>
+    /// </summary>
+    public Func<string, bool> UnknownResponseHandler { get; set; } = _ => false;
+
+    public AnsiResponseParser () : base (new StringHeld ()) { }
+
+    public string ProcessInput (string input)
+    {
+        var output = new StringBuilder ();
+
+        ProcessInputBase (
+                          i => input [i],
+                          i => input [i], // For string there is no T so object is same as char
+                          c => output.Append ((char)c),
+                          input.Length);
+
+        return output.ToString ();
+    }
+
+    public string Release ()
+    {
+        lock (lockState)
+        {
+            string output = heldContent.HeldToString ();
+            ResetState ();
+
+            return output;
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override bool ShouldSwallowUnexpectedResponse () { return UnknownResponseHandler.Invoke (heldContent.HeldToString ()); }
+}

--- a/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/AnsiResponseParserState.cs
+++ b/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/AnsiResponseParserState.cs
@@ -1,0 +1,24 @@
+﻿namespace Terminal.Gui;
+
+/// <summary>
+///     Describes the current state of an <see cref="IAnsiResponseParser"/>
+/// </summary>
+public enum AnsiResponseParserState
+{
+    /// <summary>
+    ///     Parser is reading normal input e.g. keys typed by user.
+    /// </summary>
+    Normal,
+
+    /// <summary>
+    ///     Parser has encountered an Esc and is waiting to see if next
+    ///     key(s) continue to form an Ansi escape sequence
+    /// </summary>
+    ExpectingBracket,
+
+    /// <summary>
+    ///     Parser has encountered Esc[ and considers that it is in the process
+    ///     of reading an ANSI sequence.
+    /// </summary>
+    InResponse
+}

--- a/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/GenericHeld.cs
+++ b/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/GenericHeld.cs
@@ -1,0 +1,19 @@
+﻿#nullable enable
+namespace Terminal.Gui;
+
+/// <summary>
+///     Implementation of <see cref="IHeld"/> for <see cref="AnsiResponseParser{T}"/>
+/// </summary>
+/// <typeparam name="T"></typeparam>
+internal class GenericHeld<T> : IHeld
+{
+    private readonly List<Tuple<char, T>> held = new ();
+
+    public void ClearHeld () { held.Clear (); }
+
+    public string HeldToString () { return new (held.Select (h => h.Item1).ToArray ()); }
+
+    public IEnumerable<object> HeldToObjects () { return held; }
+
+    public void AddToHeld (object o) { held.Add ((Tuple<char, T>)o); }
+}

--- a/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/IAnsiResponseParser.cs
+++ b/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/IAnsiResponseParser.cs
@@ -1,0 +1,54 @@
+﻿#nullable enable
+namespace Terminal.Gui;
+
+/// <summary>
+///     When implemented in a derived class, allows watching an input stream of characters
+///     (i.e. console input) for ANSI response sequences.
+/// </summary>
+public interface IAnsiResponseParser
+{
+    /// <summary>
+    ///     Current state of the parser based on what sequence of characters it has
+    ///     read from the console input stream.
+    /// </summary>
+    AnsiResponseParserState State { get; }
+
+    /// <summary>
+    ///     Notifies the parser that you are expecting a response to come in
+    ///     with the given <paramref name="terminator"/> (i.e. because you have
+    ///     sent an ANSI request out).
+    /// </summary>
+    /// <param name="terminator">The terminator you expect to see on response.</param>
+    /// <param name="response">Callback to invoke when the response is seen in console input.</param>
+    /// <param name="abandoned"></param>
+    /// <param name="persistent">
+    ///     <see langword="true"/> if you want this to persist permanently
+    ///     and be raised for every event matching the <paramref name="terminator"/>.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    ///     If trying to register a persistent request for a terminator
+    ///     that already has one.
+    ///     exists.
+    /// </exception>
+    void ExpectResponse (string terminator, Action<string> response, Action? abandoned, bool persistent);
+
+    /// <summary>
+    ///     Returns true if there is an existing expectation (i.e. we are waiting a response
+    ///     from console) for the given <paramref name="terminator"/>.
+    /// </summary>
+    /// <param name="terminator"></param>
+    /// <returns></returns>
+    bool IsExpecting (string terminator);
+
+    /// <summary>
+    ///     Removes callback and expectation that we will get a response for the
+    ///     given <pararef name="requestTerminator"/>. Use to give up on very old
+    ///     requests e.g. if you want to send a different one with the same terminator.
+    /// </summary>
+    /// <param name="requestTerminator"></param>
+    /// <param name="persistent">
+    ///     <see langword="true"/> if you want to remove a persistent
+    ///     request listener.
+    /// </param>
+    void StopExpecting (string requestTerminator, bool persistent);
+}

--- a/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/IHeld.cs
+++ b/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/IHeld.cs
@@ -1,0 +1,33 @@
+﻿#nullable enable
+namespace Terminal.Gui;
+
+/// <summary>
+///     Describes a sequence of chars (and optionally T metadata) accumulated
+///     by an <see cref="IAnsiResponseParser"/>
+/// </summary>
+internal interface IHeld
+{
+    /// <summary>
+    ///     Clears all held objects
+    /// </summary>
+    void ClearHeld ();
+
+    /// <summary>
+    ///     Returns string representation of the held objects
+    /// </summary>
+    /// <returns></returns>
+    string HeldToString ();
+
+    /// <summary>
+    ///     Returns the collection objects directly e.g. <see langword="char"/>
+    ///     or <see cref="Tuple"/> <see langword="char"/> + metadata T
+    /// </summary>
+    /// <returns></returns>
+    IEnumerable<object> HeldToObjects ();
+
+    /// <summary>
+    ///     Adds the given object to the collection.
+    /// </summary>
+    /// <param name="o"></param>
+    void AddToHeld (object o);
+}

--- a/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/StringHeld.cs
+++ b/Terminal.Gui/ConsoleDrivers/AnsiEscapeSequence/StringHeld.cs
@@ -1,0 +1,18 @@
+﻿#nullable enable
+namespace Terminal.Gui;
+
+/// <summary>
+///     Implementation of <see cref="IHeld"/> for <see cref="AnsiResponseParser"/>
+/// </summary>
+internal class StringHeld : IHeld
+{
+    private readonly StringBuilder held = new ();
+
+    public void ClearHeld () { held.Clear (); }
+
+    public string HeldToString () { return held.ToString (); }
+
+    public IEnumerable<object> HeldToObjects () { return held.ToString ().Select (c => (object)c); }
+
+    public void AddToHeld (object o) { held.Append ((char)o); }
+}

--- a/UnitTests/ConsoleDrivers/AnsiResponseParserTests.cs
+++ b/UnitTests/ConsoleDrivers/AnsiResponseParserTests.cs
@@ -1,0 +1,639 @@
+﻿using System.Diagnostics;
+using System.Text;
+using Xunit.Abstractions;
+
+namespace UnitTests.ConsoleDrivers;
+public class AnsiResponseParserTests (ITestOutputHelper output)
+{
+    AnsiResponseParser<int> _parser1 = new AnsiResponseParser<int> ();
+    AnsiResponseParser _parser2 = new AnsiResponseParser ();
+
+    /// <summary>
+    /// Used for the T value in batches that are passed to the  AnsiResponseParser&lt;int&gt;  (parser1)
+    /// </summary>
+    private int tIndex = 0;
+
+    [Fact]
+    public void TestInputProcessing ()
+    {
+        string ansiStream = "\u001b[<0;10;20M" +   // ANSI escape for mouse move at (10, 20)
+                            "Hello" +             // User types "Hello"
+                            "\u001b[0c";            // Device Attributes response (e.g., terminal identification i.e. DAR)
+
+
+        string response1 = null;
+        string response2 = null;
+
+        int i = 0;
+
+        // Imagine that we are expecting a DAR
+        _parser1.ExpectResponse ("c", (s) => response1 = s, null, false);
+        _parser2.ExpectResponse ("c", (s) => response2 = s, null, false);
+
+        // First char is Escape which we must consume incase what follows is the DAR
+        AssertConsumed (ansiStream, ref i); // Esc
+
+        for (int c = 0; c < "[<0;10;20".Length; c++)
+        {
+            AssertConsumed (ansiStream, ref i);
+        }
+
+        // We see the M terminator
+        AssertReleased (ansiStream, ref i, "\u001b[<0;10;20M");
+
+        // Regular user typing
+        for (int c = 0; c < "Hello".Length; c++)
+        {
+            AssertIgnored (ansiStream, "Hello" [c], ref i);
+        }
+
+        // Now we have entered the actual DAR we should be consuming these
+        for (int c = 0; c < "\u001b[0".Length; c++)
+        {
+            AssertConsumed (ansiStream, ref i);
+        }
+
+        // Consume the terminator 'c' and expect this to call the above event
+        Assert.Null (response1);
+        Assert.Null (response1);
+        AssertConsumed (ansiStream, ref i);
+        Assert.NotNull (response2);
+        Assert.Equal ("\u001b[0c", response2);
+        Assert.NotNull (response2);
+        Assert.Equal ("\u001b[0c", response2);
+    }
+
+    [Theory]
+    [InlineData ("\u001b[<0;10;20MHi\u001b[0c", "c", "\u001b[0c", "\u001b[<0;10;20MHi")]
+    [InlineData ("\u001b[<1;15;25MYou\u001b[1c", "c", "\u001b[1c", "\u001b[<1;15;25MYou")]
+    [InlineData ("\u001b[0cHi\u001b[0c", "c", "\u001b[0c", "Hi\u001b[0c")]
+    [InlineData ("\u001b[<0;0;0MHe\u001b[3c", "c", "\u001b[3c", "\u001b[<0;0;0MHe")]
+    [InlineData ("\u001b[<0;1;2Da\u001b[0c\u001b[1c", "c", "\u001b[0c", "\u001b[<0;1;2Da\u001b[1c")]
+    [InlineData ("\u001b[1;1M\u001b[3cAn", "c", "\u001b[3c", "\u001b[1;1MAn")]
+    [InlineData ("hi\u001b[2c\u001b[<5;5;5m", "c", "\u001b[2c", "hi\u001b[<5;5;5m")]
+    [InlineData ("\u001b[3c\u001b[4c\u001b[<0;0;0MIn", "c", "\u001b[3c", "\u001b[4c\u001b[<0;0;0MIn")]
+    [InlineData ("\u001b[<1;2;3M\u001b[0c\u001b[<1;2;3M\u001b[2c", "c", "\u001b[0c", "\u001b[<1;2;3M\u001b[<1;2;3M\u001b[2c")]
+    [InlineData ("\u001b[<0;1;1MHi\u001b[6c\u001b[2c\u001b[<1;0;0MT", "c", "\u001b[6c", "\u001b[<0;1;1MHi\u001b[2c\u001b[<1;0;0MT")]
+    [InlineData ("Te\u001b[<2;2;2M\u001b[7c", "c", "\u001b[7c", "Te\u001b[<2;2;2M")]
+    [InlineData ("\u001b[0c\u001b[<0;0;0M\u001b[3c\u001b[0c\u001b[1;0MT", "c", "\u001b[0c", "\u001b[<0;0;0M\u001b[3c\u001b[0c\u001b[1;0MT")]
+    [InlineData ("\u001b[0;0M\u001b[<0;0;0M\u001b[3cT\u001b[1c", "c", "\u001b[3c", "\u001b[0;0M\u001b[<0;0;0MT\u001b[1c")]
+    [InlineData ("\u001b[3c\u001b[<0;0;0M\u001b[0c\u001b[<1;1;1MIn\u001b[1c", "c", "\u001b[3c", "\u001b[<0;0;0M\u001b[0c\u001b[<1;1;1MIn\u001b[1c")]
+    [InlineData ("\u001b[<5;5;5M\u001b[7cEx\u001b[8c", "c", "\u001b[7c", "\u001b[<5;5;5MEx\u001b[8c")]
+
+    // Random characters and mixed inputs
+    [InlineData ("\u001b[<1;1;1MJJ\u001b[9c", "c", "\u001b[9c", "\u001b[<1;1;1MJJ")] // Mixed text
+    [InlineData ("Be\u001b[0cAf", "c", "\u001b[0c", "BeAf")] // Escape in the middle of the string
+    [InlineData ("\u001b[<0;0;0M\u001b[2cNot e", "c", "\u001b[2c", "\u001b[<0;0;0MNot e")] // Unexpected sequence followed by text
+    [InlineData ("Just te\u001b[<0;0;0M\u001b[3c\u001b[2c\u001b[4c", "c", "\u001b[3c", "Just te\u001b[<0;0;0M\u001b[2c\u001b[4c")] // Multiple unexpected responses
+    [InlineData ("\u001b[1;2;3M\u001b[0c\u001b[2;2M\u001b[0;0;0MTe", "c", "\u001b[0c", "\u001b[1;2;3M\u001b[2;2M\u001b[0;0;0MTe")] // Multiple commands with responses
+    [InlineData ("\u001b[<3;3;3Mabc\u001b[4cde", "c", "\u001b[4c", "\u001b[<3;3;3Mabcde")] // Escape sequences mixed with regular text
+
+    // Edge cases
+    [InlineData ("\u001b[0c\u001b[0c\u001b[0c", "c", "\u001b[0c", "\u001b[0c\u001b[0c")] // Multiple identical responses
+    [InlineData ("", "c", "", "")] // Empty input
+    [InlineData ("Normal", "c", "", "Normal")] // No escape sequences
+    [InlineData ("\u001b[<0;0;0M", "c", "", "\u001b[<0;0;0M")] // Escape sequence only
+    [InlineData ("\u001b[1;2;3M\u001b[0c", "c", "\u001b[0c", "\u001b[1;2;3M")] // Last response consumed
+
+    [InlineData ("Inpu\u001b[0c\u001b[1;0;0M", "c", "\u001b[0c", "Inpu\u001b[1;0;0M")] // Single input followed by escape
+    [InlineData ("\u001b[2c\u001b[<5;6;7MDa", "c", "\u001b[2c", "\u001b[<5;6;7MDa")] // Multiple escape sequences followed by text
+    [InlineData ("\u001b[0cHi\u001b[1cGo", "c", "\u001b[0c", "Hi\u001b[1cGo")] // Normal text with multiple escape sequences
+
+    [InlineData ("\u001b[<1;1;1MTe", "c", "", "\u001b[<1;1;1MTe")]
+    // Add more test cases here...
+    public void TestInputSequences (string ansiStream, string expectedTerminator, string expectedResponse, string expectedOutput)
+    {
+        var swGenBatches = Stopwatch.StartNew ();
+        int tests = 0;
+
+        var permutations = GetBatchPermutations (ansiStream, 5).ToArray ();
+
+        swGenBatches.Stop ();
+        var swRunTest = Stopwatch.StartNew ();
+
+        foreach (var batchSet in permutations)
+        {
+            tIndex = 0;
+            string response1 = string.Empty;
+            string response2 = string.Empty;
+
+            // Register the expected response with the given terminator
+            _parser1.ExpectResponse (expectedTerminator, s => response1 = s, null, false);
+            _parser2.ExpectResponse (expectedTerminator, s => response2 = s, null, false);
+
+            // Process the input
+            StringBuilder actualOutput1 = new StringBuilder ();
+            StringBuilder actualOutput2 = new StringBuilder ();
+
+            foreach (var batch in batchSet)
+            {
+                var output1 = _parser1.ProcessInput (StringToBatch (batch));
+                actualOutput1.Append (BatchToString (output1));
+
+                var output2 = _parser2.ProcessInput (batch);
+                actualOutput2.Append (output2);
+            }
+
+            // Assert the final output minus the expected response
+            Assert.Equal (expectedOutput, actualOutput1.ToString ());
+            Assert.Equal (expectedResponse, response1);
+            Assert.Equal (expectedOutput, actualOutput2.ToString ());
+            Assert.Equal (expectedResponse, response2);
+            tests++;
+        }
+
+        output.WriteLine ($"Tested {tests} in {swRunTest.ElapsedMilliseconds} ms (gen batches took {swGenBatches.ElapsedMilliseconds} ms)");
+    }
+
+    public static IEnumerable<object []> TestInputSequencesExact_Cases ()
+    {
+        yield return
+        [
+            "Esc Only",
+            null,
+            new []
+            {
+                new StepExpectation ('\u001b',AnsiResponseParserState.ExpectingBracket,string.Empty)
+            }
+        ];
+
+        yield return
+        [
+            "Esc Hi with intermediate",
+            'c',
+            new []
+            {
+                new StepExpectation ('\u001b',AnsiResponseParserState.ExpectingBracket,string.Empty),
+                new StepExpectation ('H',AnsiResponseParserState.Normal,"\u001bH"), // H is known terminator and not expected one so here we release both chars
+                new StepExpectation ('\u001b',AnsiResponseParserState.ExpectingBracket,string.Empty),
+                new StepExpectation ('[',AnsiResponseParserState.InResponse,string.Empty),
+                new StepExpectation ('0',AnsiResponseParserState.InResponse,string.Empty),
+                new StepExpectation ('c',AnsiResponseParserState.Normal,string.Empty,"\u001b[0c"), // c is expected terminator so here we swallow input and populate expected response
+                new StepExpectation ('\u001b',AnsiResponseParserState.ExpectingBracket,string.Empty),
+            }
+        ];
+    }
+
+    public class StepExpectation ()
+    {
+        /// <summary>
+        /// The input character to feed into the parser at this step of the test
+        /// </summary>
+        public char Input { get; }
+
+        /// <summary>
+        /// What should the state of the parser be after the <see cref="Input"/>
+        /// is fed in.
+        /// </summary>
+        public AnsiResponseParserState ExpectedStateAfterOperation { get; }
+
+        /// <summary>
+        /// If this step should release one or more characters, put them here.
+        /// </summary>
+        public string ExpectedRelease { get; } = string.Empty;
+
+        /// <summary>
+        /// If this step should result in a completing of detection of ANSI response
+        /// then put the expected full response sequence here.
+        /// </summary>
+        public string ExpectedAnsiResponse { get; } = string.Empty;
+
+        public StepExpectation (
+            char input,
+            AnsiResponseParserState expectedStateAfterOperation,
+            string expectedRelease = "",
+            string expectedAnsiResponse = "") : this ()
+        {
+            Input = input;
+            ExpectedStateAfterOperation = expectedStateAfterOperation;
+            ExpectedRelease = expectedRelease;
+            ExpectedAnsiResponse = expectedAnsiResponse;
+        }
+
+    }
+
+
+
+    [MemberData (nameof (TestInputSequencesExact_Cases))]
+    [Theory]
+    public void TestInputSequencesExact (string caseName, char? terminator, IEnumerable<StepExpectation> expectedStates)
+    {
+        output.WriteLine ("Running test case:" + caseName);
+
+        var parser = new AnsiResponseParser ();
+        string response = null;
+
+        if (terminator.HasValue)
+        {
+            parser.ExpectResponse (terminator.Value.ToString (), (s) => response = s, null, false);
+        }
+        foreach (var state in expectedStates)
+        {
+            // If we expect the response to be detected at this step
+            if (!string.IsNullOrWhiteSpace (state.ExpectedAnsiResponse))
+            {
+                // Then before passing input it should be null
+                Assert.Null (response);
+            }
+
+            var actual = parser.ProcessInput (state.Input.ToString ());
+
+            Assert.Equal (state.ExpectedRelease, actual);
+            Assert.Equal (state.ExpectedStateAfterOperation, parser.State);
+
+            // If we expect the response to be detected at this step
+            if (!string.IsNullOrWhiteSpace (state.ExpectedAnsiResponse))
+            {
+                // And after passing input it shuld be the expected value
+                Assert.Equal (state.ExpectedAnsiResponse, response);
+            }
+        }
+    }
+
+    [Fact]
+    public void ReleasesEscapeAfterTimeout ()
+    {
+        string input = "\u001b";
+        int i = 0;
+
+        // Esc on its own looks like it might be an esc sequence so should be consumed
+        AssertConsumed (input, ref i);
+
+        // We should know when the state changed
+        Assert.Equal (AnsiResponseParserState.ExpectingBracket, _parser1.State);
+        Assert.Equal (AnsiResponseParserState.ExpectingBracket, _parser2.State);
+
+        Assert.Equal (DateTime.Now.Date, _parser1.StateChangedAt.Date);
+        Assert.Equal (DateTime.Now.Date, _parser2.StateChangedAt.Date);
+
+        AssertManualReleaseIs (input);
+    }
+
+
+    [Fact]
+    public void TwoExcapesInARow ()
+    {
+        // Example user presses Esc key then a DAR comes in
+        string input = "\u001b\u001b";
+        int i = 0;
+
+        // First Esc gets grabbed
+        AssertConsumed (input, ref i);
+
+        // Upon getting the second Esc we should release the first
+        AssertReleased (input, ref i, "\u001b", 0);
+
+        // Assume 50ms or something has passed, lets force release as no new content
+
+        // It should be the second escape that gets released (i.e. index 1)
+        AssertManualReleaseIs ("\u001b", 1);
+    }
+
+    [Fact]
+    public void TwoExcapesInARowWithTextBetween ()
+    {
+        // Example user presses Esc key and types at the speed of light (normally the consumer should be handling Esc timeout)
+        // then a DAR comes in.
+        string input = "\u001bfish\u001b";
+        int i = 0;
+
+        // First Esc gets grabbed
+        AssertConsumed (input, ref i); // Esc
+        Assert.Equal (AnsiResponseParserState.ExpectingBracket, _parser1.State);
+        Assert.Equal (AnsiResponseParserState.ExpectingBracket, _parser2.State);
+
+        // Because next char is 'f' we do not see a bracket so release both
+        AssertReleased (input, ref i, "\u001bf", 0, 1); // f
+
+        Assert.Equal (AnsiResponseParserState.Normal, _parser1.State);
+        Assert.Equal (AnsiResponseParserState.Normal, _parser2.State);
+
+        AssertReleased (input, ref i, "i", 2);
+        AssertReleased (input, ref i, "s", 3);
+        AssertReleased (input, ref i, "h", 4);
+
+        AssertConsumed (input, ref i); // Second Esc
+
+        // Assume 50ms or something has passed, lets force release as no new content
+        AssertManualReleaseIs ("\u001b", 5);
+    }
+
+    [Fact]
+    public void TestLateResponses ()
+    {
+        var p = new AnsiResponseParser ();
+
+        string responseA = null;
+        string responseB = null;
+
+        p.ExpectResponse ("z", (r) => responseA = r, null, false);
+
+        // Some time goes by without us seeing a response
+        p.StopExpecting ("z", false);
+
+        // Send our new request
+        p.ExpectResponse ("z", (r) => responseB = r, null, false);
+
+        // Because we gave up on getting A, we should expect the response to be to our new request
+        Assert.Empty (p.ProcessInput ("\u001b[<1;2z"));
+        Assert.Null (responseA);
+        Assert.Equal ("\u001b[<1;2z", responseB);
+
+        // Oh looks like we got one late after all - swallow it
+        Assert.Empty (p.ProcessInput ("\u001b[0000z"));
+
+        // Do not expect late responses to be populated back to your variable
+        Assert.Null (responseA);
+        Assert.Equal ("\u001b[<1;2z", responseB);
+
+        // We now have no outstanding requests (late or otherwise) so new ansi codes should just fall through
+        Assert.Equal ("\u001b[111z", p.ProcessInput ("\u001b[111z"));
+
+    }
+
+    [Fact]
+    public void TestPersistentResponses ()
+    {
+        var p = new AnsiResponseParser ();
+
+        int m = 0;
+        int M = 1;
+
+        p.ExpectResponse ("m", _ => m++, null, true);
+        p.ExpectResponse ("M", _ => M++, null, true);
+
+        // Act - Feed input strings containing ANSI sequences
+        p.ProcessInput ("\u001b[<0;10;10m");  // Should match and increment `m`
+        p.ProcessInput ("\u001b[<0;20;20m");  // Should match and increment `m`
+        p.ProcessInput ("\u001b[<0;30;30M");  // Should match and increment `M`
+        p.ProcessInput ("\u001b[<0;40;40M");  // Should match and increment `M`
+        p.ProcessInput ("\u001b[<0;50;50M");  // Should match and increment `M`
+
+        // Assert - Verify that counters reflect the expected counts of each terminator
+        Assert.Equal (2, m);  // Expected two `m` responses
+        Assert.Equal (4, M);  // Expected three `M` responses plus the initial value of 1
+    }
+
+    [Fact]
+    public void TestPersistentResponses_WithMetadata ()
+    {
+        var p = new AnsiResponseParser<int> ();
+
+        int m = 0;
+
+        var result = new List<Tuple<char, int>> ();
+
+        p.ExpectResponseT ("m", (r) =>
+        {
+            result = r.ToList ();
+            m++;
+        },
+                           null, true);
+
+        // Act - Feed input strings containing ANSI sequences
+        p.ProcessInput (StringToBatch ("\u001b[<0;10;10m"));  // Should match and increment `m`
+
+        // Prepare expected result: 
+        var expected = new List<Tuple<char, int>>
+        {
+            Tuple.Create('\u001b', 0), // Escape character
+            Tuple.Create('[', 1),
+            Tuple.Create('<', 2),
+            Tuple.Create('0', 3),
+            Tuple.Create(';', 4),
+            Tuple.Create('1', 5),
+            Tuple.Create('0', 6),
+            Tuple.Create(';', 7),
+            Tuple.Create('1', 8),
+            Tuple.Create('0', 9),
+            Tuple.Create('m', 10)
+        };
+
+        Assert.Equal (expected.Count, result.Count); // Ensure the count is as expected
+        Assert.True (expected.SequenceEqual (result), "The result does not match the expected output."); // Check the actual content
+    }
+
+    [Fact]
+    public void ShouldSwallowUnknownResponses_WhenDelegateSaysSo ()
+    {
+        int i = 0;
+
+        // Swallow all unknown escape codes
+        _parser1.UnexpectedResponseHandler = _ => true;
+        _parser2.UnknownResponseHandler = _ => true;
+
+
+        AssertReleased (
+                        "Just te\u001b[<0;0;0M\u001b[3c\u001b[2c\u001b[4cst",
+                        "Just test",
+                        0,
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        28,
+                        29);
+    }
+
+    [Fact]
+    public void UnknownResponses_ParameterShouldMatch ()
+    {
+        int i = 0;
+
+        // Track unknown responses passed to the UnexpectedResponseHandler
+        var unknownResponses = new List<string> ();
+
+        // Set up the UnexpectedResponseHandler to log each unknown response
+        _parser1.UnexpectedResponseHandler = r1 =>
+        {
+            unknownResponses.Add (BatchToString (r1));
+            return true; // Return true to swallow unknown responses
+        };
+
+        _parser2.UnknownResponseHandler = r2 =>
+        {
+            // parsers should be agreeing on what these responses are!
+            Assert.Equal (unknownResponses.Last (), r2);
+            return true; // Return true to swallow unknown responses
+        };
+
+        // Input with known and unknown responses
+        AssertReleased (
+                        "Just te\u001b[<0;0;0M\u001b[3c\u001b[2c\u001b[4cst",
+                        "Just test");
+
+        // Expected unknown responses (ANSI sequences that are unknown)
+        var expectedUnknownResponses = new List<string>
+        {
+            "\u001b[<0;0;0M",
+            "\u001b[3c",
+            "\u001b[2c",
+            "\u001b[4c"
+        };
+
+        // Assert that the UnexpectedResponseHandler was called with the correct unknown responses
+        Assert.Equal (expectedUnknownResponses.Count, unknownResponses.Count);
+        Assert.Equal (expectedUnknownResponses, unknownResponses);
+    }
+
+    private Tuple<char, int> [] StringToBatch (string batch)
+    {
+        return batch.Select ((k) => Tuple.Create (k, tIndex++)).ToArray ();
+    }
+
+    public static IEnumerable<string []> GetBatchPermutations (string input, int maxDepth = 3)
+    {
+        // Call the recursive method to generate batches with an initial depth of 0
+        return GenerateBatches (input, 0, maxDepth, 0);
+    }
+
+    private static IEnumerable<string []> GenerateBatches (string input, int start, int maxDepth, int currentDepth)
+    {
+        // If we have reached the maximum recursion depth, return no results
+        if (currentDepth >= maxDepth)
+        {
+            yield break; // No more batches can be generated at this depth
+        }
+
+        // If we have reached the end of the string, return an empty list
+        if (start >= input.Length)
+        {
+            yield return new string [0];
+            yield break;
+        }
+
+        // Iterate over the input string to create batches
+        for (int i = start + 1; i <= input.Length; i++)
+        {
+            // Take a batch from 'start' to 'i'
+            string batch = input.Substring (start, i - start);
+
+            // Recursively get batches from the remaining substring, increasing the depth
+            foreach (var remainingBatches in GenerateBatches (input, i, maxDepth, currentDepth + 1))
+            {
+                // Combine the current batch with the remaining batches
+                var result = new string [1 + remainingBatches.Length];
+                result [0] = batch;
+                Array.Copy (remainingBatches, 0, result, 1, remainingBatches.Length);
+                yield return result;
+            }
+        }
+    }
+
+    private void AssertIgnored (string ansiStream, char expected, ref int i)
+    {
+        var c2 = ansiStream [i];
+        var c1 = NextChar (ansiStream, ref i);
+
+        // Parser does not grab this key (i.e. driver can continue with regular operations)
+        Assert.Equal (c1, _parser1.ProcessInput (c1));
+        Assert.Equal (expected, c1.Single ().Item1);
+
+        Assert.Equal (c2, _parser2.ProcessInput (c2.ToString ()).Single ());
+        Assert.Equal (expected, c2);
+    }
+    private void AssertConsumed (string ansiStream, ref int i)
+    {
+        // Parser grabs this key
+        var c2 = ansiStream [i];
+        var c1 = NextChar (ansiStream, ref i);
+
+        Assert.Empty (_parser1.ProcessInput (c1));
+        Assert.Empty (_parser2.ProcessInput (c2.ToString ()));
+    }
+
+    /// <summary>
+    /// Overload that fully exhausts <paramref name="ansiStream"/> and asserts
+    /// that the final released content across whole processing is <paramref name="expectedRelease"/>
+    /// </summary>
+    /// <param name="ansiStream"></param>
+    /// <param name="expectedRelease"></param>
+    /// <param name="expectedTValues"></param>
+    private void AssertReleased (string ansiStream, string expectedRelease, params int [] expectedTValues)
+    {
+        var sb = new StringBuilder ();
+        var tValues = new List<int> ();
+
+        int i = 0;
+
+        while (i < ansiStream.Length)
+        {
+            var c2 = ansiStream [i];
+            var c1 = NextChar (ansiStream, ref i);
+
+            var released1 = _parser1.ProcessInput (c1).ToArray ();
+            tValues.AddRange (released1.Select (kv => kv.Item2));
+
+
+            var released2 = _parser2.ProcessInput (c2.ToString ());
+
+            // Both parsers should have same chars so release chars consistently with each other
+            Assert.Equal (BatchToString (released1), released2);
+
+            sb.Append (released2);
+        }
+
+        Assert.Equal (expectedRelease, sb.ToString ());
+
+        if (expectedTValues.Length > 0)
+        {
+            Assert.True (expectedTValues.SequenceEqual (tValues));
+        }
+    }
+
+    /// <summary>
+    /// Asserts that <paramref name="i"/> index of <see cref="ansiStream"/> when consumed will release
+    /// <paramref name="expectedRelease"/>. Results in implicit increment of <paramref name="i"/>.
+    /// <remarks>Note that this does NOT iteratively consume all the stream, only 1 char at <paramref name="i"/></remarks>
+    /// </summary>
+    /// <param name="ansiStream"></param>
+    /// <param name="i"></param>
+    /// <param name="expectedRelease"></param>
+    /// <param name="expectedTValues"></param>
+    private void AssertReleased (string ansiStream, ref int i, string expectedRelease, params int [] expectedTValues)
+    {
+        var c2 = ansiStream [i];
+        var c1 = NextChar (ansiStream, ref i);
+
+        // Parser realizes it has grabbed content that does not belong to an outstanding request
+        // Parser returns false to indicate to continue
+        var released1 = _parser1.ProcessInput (c1).ToArray ();
+        Assert.Equal (expectedRelease, BatchToString (released1));
+
+        if (expectedTValues.Length > 0)
+        {
+            Assert.True (expectedTValues.SequenceEqual (released1.Select (kv => kv.Item2)));
+        }
+
+        Assert.Equal (expectedRelease, _parser2.ProcessInput (c2.ToString ()));
+    }
+
+    private string BatchToString (IEnumerable<Tuple<char, int>> processInput)
+    {
+        return new string (processInput.Select (a => a.Item1).ToArray ());
+    }
+
+    private Tuple<char, int> [] NextChar (string ansiStream, ref int i)
+    {
+        return StringToBatch (ansiStream [i++].ToString ());
+    }
+    private void AssertManualReleaseIs (string expectedRelease, params int [] expectedTValues)
+    {
+
+        // Consumer is responsible for determining this based on  e.g. after 50ms
+        var released1 = _parser1.Release ().ToArray ();
+        Assert.Equal (expectedRelease, BatchToString (released1));
+
+        if (expectedTValues.Length > 0)
+        {
+            Assert.True (expectedTValues.SequenceEqual (released1.Select (kv => kv.Item2)));
+        }
+
+        Assert.Equal (expectedRelease, _parser2.Release ());
+
+        Assert.Equal (AnsiResponseParserState.Normal, _parser1.State);
+        Assert.Equal (AnsiResponseParserState.Normal, _parser2.State);
+    }
+}


### PR DESCRIPTION
This is a WIP but please take a look.

It replaces all the 'incomplete CKI' and response parsing code in NetEvents with `AnsiResponseParser<ConsoleKeyInfo>`

How it works:

- Instead of telling the parser what to expect we just route everything (using `UnexpectedResponseHandler`) straight to `ProcessRequestResponse` (returning true to swallow).
- `ProcessInputQueue` simply becomes a matter of passing the keys to the parser and then iterating the released keys (if any)
  - Regular keystrokes are released by the parser
  - All escape sequences are consumed and passed to `ProcessRequestResponse`

I have also included the tests so you can see how comprehensive they are.

This is a first pass so may not be perfect - please can you experiment and see if this simplifies/improves the blocking issues and parsing issues you've been having?